### PR TITLE
Add Docker Configuration for API Gateway

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,0 +1,12 @@
+server.port=8080
+
+# Eureka Server URL
+eureka.client.serviceUrl.defaultZone=http://root:root@discovery-server:8761/eureka
+
+# OAuth2 Configuration
+spring.security.oauth2.resourceserver.jwt.issuer-uri= http://keycloak:8080/realms/spring-boot-shopping-realm
+
+# Zipkin Configuration
+management.zipkin.tracing.endpoint=http://zipkin:9411
+
+app.eureka-server=discovery-server


### PR DESCRIPTION
### Description:
This pull request introduces Docker-specific configuration properties for the API Gateway service.

### Changes:
- **application-docker.properties:** Added a new properties file in the `src/main/resources` directory to configure the application for Docker environments.
- **Server Port:** Configures the server port to `8080` using the `server.port` property.
- **Eureka Server URL:** Sets the Eureka Server URL to `http://root:root@discovery-server:8761/eureka` using the `eureka.client.serviceUrl.defaultZone` property.
- **OAuth2 Resource Server JWT Issuer URI:** Configures the OAuth2 Resource Server JWT issuer URI to `http://keycloak:8080/realms/spring-boot-shopping-realm` using the `spring.security.oauth2.resourceserver.jwt.issuer-uri` property.
- **Zipkin Tracing Endpoint:** Sets the Zipkin tracing endpoint to `http://zipkin:9411` using the `management.zipkin.tracing.endpoint` property.
- **Eureka Server Service Name:** Specifies the Eureka Server service name as `discovery-server` using the `app.eureka-server` property.

### Purpose:
The purpose of this pull request is to introduce Docker-specific configuration properties for the API Gateway service. These properties are intended to be used when running the application in a Docker container environment. The configurations include setting up the Eureka Server URL, OAuth2 Resource Server JWT issuer URI, Zipkin tracing endpoint, and other relevant settings specific to the Docker environment. This pull request ensures that the API Gateway service can properly connect to other services and components when deployed in a Docker-based infrastructure.