### PR TITLE
Configure Logging and Externalize Eureka Server URL

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,5 +1,8 @@
 server.port=8080
 
+# Logging level
+logging.level.org.springframework.security=TRACE
+
 # Eureka Server URL
 eureka.client.serviceUrl.defaultZone=http://root:root@discovery-server:8761/eureka
 
@@ -9,4 +12,5 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri= http://keycloak:8080/realm
 # Zipkin Configuration
 management.zipkin.tracing.endpoint=http://zipkin:9411
 
+# Host
 app.eureka-server=discovery-server

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,9 @@ server.port=8080
 # Eureka Server URL
 eureka.client.service-url.default-zone=http://root:root@localhost:8761/eureka
 
+# Host
+app.eureka-server=localhost
+
 # Application Name
 spring.application.name=api-gateway
 
@@ -28,13 +31,13 @@ spring.cloud.gateway.routes[2].predicates[0]=Path=/api/inventory/**
 
 # Discovery Service Routes
 spring.cloud.gateway.routes[3].id=discovery-service
-spring.cloud.gateway.routes[3].uri=http://localhost:8761
+spring.cloud.gateway.routes[3].uri=http://${app.eureka-server}:8761
 spring.cloud.gateway.routes[3].predicates[0]=Path=/eureka
 spring.cloud.gateway.routes[3].filters[0]=SetPath=/
 
 # Discovery Service Static Resources Routes
 spring.cloud.gateway.routes[4].id=discovery-service-static
-spring.cloud.gateway.routes[4].uri=http://localhost:8761
+spring.cloud.gateway.routes[4].uri=http://${app.eureka-server}:8761
 spring.cloud.gateway.routes[4].predicates[0]=Path=/eureka/**
 
 # OAuth2 Configuration


### PR DESCRIPTION
### Description:
This pull request introduces configuration enhancements for the API Gateway service, including adjustments to logging levels and externalization of the Eureka Server URL.

### Changes:
- **Logging Configuration:** Configures the logging level for `org.springframework.security` to `TRACE` using the `logging.level.org.springframework.security` property in the `application-docker.properties` file.
- **Eureka Server URL Externalization:** Externalizes the Eureka Server URL by introducing the `app.eureka-server` property and setting its value to `discovery-server` in the `application-docker.properties` file.
- **Local Eureka Server Configuration:** Introduces the `app.eureka-server` property and sets its value to `localhost` in the `application.properties` file.
- **Gateway Route Configuration:** Updates the Eureka Server URL in the `spring.cloud.gateway.routes[3].uri` and `spring.cloud.gateway.routes[4].uri` properties to use the `${app.eureka-server}` placeholder instead of hardcoding the hostname in both `application-docker.properties` and `application.properties` files.

### Purpose:
The purpose of this pull request is to enhance the configuration of the API Gateway service by adjusting the logging level for Spring Security and externalizing the Eureka Server URL. By setting the logging level to `TRACE`, more detailed log messages related to Spring Security will be generated, which can be useful for debugging and troubleshooting purposes. Additionally, by externalizing the Eureka Server URL, the API Gateway can be configured to connect to different Eureka Server instances (e.g., localhost for local development, discovery-server for Docker environment) without modifying the codebase. This change improves the flexibility and maintainability of the application configuration.