### PR TITLE
Add Prometheus Metrics Support to API Gateway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing-bridge-brave</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,3 +46,6 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8181/realm
 # Zipkin Configuration
 management.zipkin.tracing.endpoint=http://localhost:9411/api/v2/spans
 management.tracing.sampling.probability=1.0
+
+# Actuator Prometheus Endpoint
+management.endpoints.web.exposure.include=prometheus


### PR DESCRIPTION
### Description:
This pull request introduces changes to enable Prometheus metrics collection and monitoring in the API Gateway microservice.

### Changes:
- **Add Prometheus Metrics Support:** Added dependency for `micrometer-registry-prometheus` to enable Prometheus metrics collection.
- **Configure Prometheus Endpoint:** Configured Prometheus actuator endpoint in `application.properties` by adding `management.endpoints.web.exposure.include=prometheus`.

### Purpose:
The purpose of this pull request is to integrate the API Gateway microservice with Prometheus for monitoring and collecting metrics. By adding the Prometheus registry and exposing the Prometheus actuator endpoint, the API Gateway can be scraped by Prometheus, allowing for visualization and analysis of various metrics such as request rates, response times, and system resource utilization. This enhancement improves observability and aids in monitoring the health and performance of the API Gateway.