### PR TITLE
Fix Zipkin Tracing Endpoint Configuration

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -10,7 +10,7 @@ eureka.client.serviceUrl.defaultZone=http://root:root@discovery-server:8761/eure
 spring.security.oauth2.resourceserver.jwt.issuer-uri= http://keycloak:8080/realms/spring-boot-shopping-realm
 
 # Zipkin Configuration
-management.zipkin.tracing.endpoint=http://zipkin:9411
+management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans
 
 # Host
 app.eureka-server=discovery-server


### PR DESCRIPTION
### Description:
This pull request fixes the configuration for the Zipkin tracing endpoint in the API Gateway service when running in a Docker environment.

### Changes:
- **Fix Zipkin Tracing Endpoint:** Updated the `management.zipkin.tracing.endpoint` property in the `application-docker.properties` file to include the correct endpoint path `/api/v2/spans` for Zipkin.

### Purpose:
The purpose of this pull request is to ensure that the API Gateway service can correctly send tracing data to the Zipkin server when running in a Docker environment. The previous configuration was missing the `/api/v2/spans` path, which is required by Zipkin to properly receive and process the trace data. By updating this property, the API Gateway will be able to correctly send tracing data, enabling distributed tracing and monitoring of requests across the microservices.